### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/lib/apimocker.js
+++ b/lib/apimocker.js
@@ -9,7 +9,7 @@ var express = require('express'),
     untildify = require('untildify'),
     util = require('util'),
     proxy = require('express-http-proxy'),
-    uuid= require('node-uuid');
+    uuid= require('uuid');
 
 apiMocker.defaults = {
   "port": "8888",

--- a/package.json
+++ b/package.json
@@ -11,11 +11,11 @@
     "body-parser": "~1.4.3",
     "commander": ">=1",
     "express": "~4.5",
-    "node-uuid": "^1.4.6",
     "express-http-proxy": "0.6.0",
     "express-xml-bodyparser": "^0.2.2",
     "underscore": ">=1",
-    "untildify": "^2.0.0"
+    "untildify": "^2.0.0",
+    "uuid": "^3.0.0"
   },
   "devDependencies": {
     "chai": ">=1.5.0",


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.